### PR TITLE
Support createClient from url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .tern-port
+stdout

--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ resume sending when you get `drain`.
 * redis.createClient(options) = redis.createClient(6379, '127.0.0.1', options)
 * redis.createClient(unix_socket, options)
 * redis.createClient(port, host, options)
+* redis.createClient('127.0.0.1:6379', options)
+* redis.createClient('redis://127.0.0.1:6379', options)
 
 If you have `redis-server` running on the same computer as node, then the defaults for
 port and host are probably fine.  `options` in an object with the following possible properties:

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ var net = require("net"),
     to_array = require("./lib/to_array"),
     events = require("events"),
     crypto = require("crypto"),
+    url = require("url"),
     parsers = [], commands,
     connection_id = 0,
     default_port = 6379,
@@ -1227,9 +1228,25 @@ exports.createClient = function(arg0, arg1, arg2){
         return createClient_tcp(arg0, arg1, arg2);
 
     } else if( typeof arg0 === 'string' ){
-
-        // createClient( '/tmp/redis.sock', options)
-        return createClient_unix(arg0,arg1);
+        /**
+         * Support create client from given url.
+         *
+         * For example:
+         *
+         *    redis://localhost:6379
+         *    localhost:6379
+         */
+        var urlObj;
+        if (arg0.indexOf('redis://') !== -1) {
+            urlObj = url.parse(arg0);
+            return createClient_tcp(urlObj.port, urlObj.hostname);
+        } else if (arg0.indexOf(':') !== -1) {
+            urlObj = arg0.split(':');
+            return createClient_tcp(urlObj[1], urlObj[0]);
+        } else {
+            // createClient( '/tmp/redis.sock', options)
+            return createClient_unix(arg0,arg1);
+        }
 
     } else if( arg0 !== null && typeof arg0 === 'object' ){
 

--- a/test.js
+++ b/test.js
@@ -3,7 +3,7 @@ var PORT = 6379;
 var HOST = '127.0.0.1';
 
 var redis = require("./index"),
-    client = redis.createClient(PORT, HOST),
+    client = redis.createClient(HOST + ':' + PORT),
     client2 = redis.createClient(PORT, HOST),
     client3 = redis.createClient(PORT, HOST),
     bclient = redis.createClient(PORT, HOST, { return_buffers: true }),


### PR DESCRIPTION
Make user can create redis client from given url.

For example

```
var redis = require('redis');
var cli = redis.createClient('localhost:6379');

// then do something with the client.
...
```
